### PR TITLE
Update workflow for output files

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -14,14 +14,14 @@ jobs:
       shell: bash
       run: |
         version=$(./latest.sh)
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: try update
       id: update
       shell: bash
       run: |
         echo latest version ${{ steps.latest.outputs.version }}
         ./update.sh ${{ steps.latest.outputs.version }}
-        echo "::set-output name=changes::$(git diff)"
+        echo "changes=$(git diff)" >> $GITHUB_OUTPUT
     - name: create PR
       if: ${{ steps.update.outputs.changes != '' }}
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/