### PR TITLE
Use `cml pr create`

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,7 +1,7 @@
 name: Update package
 on:
   push:
-    branches: master
+    branches: main
   schedule:
     - cron: '0 0 * * *'
 jobs:
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - uses: iterative/setup-cml@v1
     - name: get latest dvc version
       id: latest
       shell: bash
@@ -24,7 +25,8 @@ jobs:
         echo "changes=$(git diff)" >> $GITHUB_OUTPUT
     - name: create PR
       if: ${{ steps.update.outputs.changes != '' }}
-      uses: peter-evans/create-pull-request@v3
-      with:
-        commit-message: dvc ${{ steps.latest.outputs.version }}
-        title: dvc ${{ steps.latest.outputs.version }}
+      run: |
+        cml pr create \
+          --token="${{ secrets.GITHUB_TOKEN }}" \
+          --message="dvc ${{ steps.latest.outputs.version }}" \
+          --title="dvc ${{ steps.latest.outputs.version }}" .


### PR DESCRIPTION
As part of an effort to use our own tools more/where appropriate cml can create the PR for these updates.

on a side note I have updated the `on: push` branch to be `main` the fact that is was still `master` probably wen unnoticed because the `schedule` component automatically uses the default/base branch which is `main`