### PR TITLE
misc changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Ruby 2.6
       uses: ruby/setup-ruby@v1.138.0
       with:
-        ruby-version: 2.6
+        ruby-version: "2.6"
     - name: Set up certificates
       env:
         ITERATIVE_APPLICATION_CERT: ${{ secrets.ITERATIVE_APPLICATION_CERT }}


### PR DESCRIPTION
* use macos-11 to build
* reduce timeout to 30 minutes, and signing back to 3600s
* add ways to run build-and-sign from PRs or workflow_dispatch
* remove lxml installation (no longer required)