### PR TITLE
osxpkg: increase timeout for locking a keychain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: Build package
 on:
+  pull_request:
   push:
     branches:
     - main
@@ -7,48 +8,42 @@ on:
 permissions:
   contents: read
   id-token: write
+
 jobs:
-  macos:
+  binary:
     runs-on: macos-11
-    environment: aws
     steps:
     - uses: actions/checkout@v3
+
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
         python-version: "3.10"
-    - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6
-    - name: Set up certificates
+
+    - name: Install app certificates
       env:
         ITERATIVE_APPLICATION_CERT: ${{ secrets.ITERATIVE_APPLICATION_CERT }}
         ITERATIVE_APPLICATION_CERT_PASS: ${{ secrets.ITERATIVE_APPLICATION_CERT_PASS }}
-        ITERATIVE_INSTALLER_CERT: ${{ secrets.ITERATIVE_INSTALLER_CERT }}
-        ITERATIVE_INSTALLER_CERT_PASS: ${{ secrets.ITERATIVE_INSTALLER_CERT_PASS }}
       run: |
         echo $ITERATIVE_APPLICATION_CERT | base64 -d > application_cert.p12
-        echo $ITERATIVE_INSTALLER_CERT | base64 -d > installer_cert.p12
         security create-keychain -p 123456 build.keychain
+        # NOTE: signing and steps before it might take longer than default 300 seconds, so we extend the
+        # timeout until the keychain automatically locks again.
+        security set-keychain-settings -lut 3600 build.keychain
         security default-keychain -s build.keychain
         security unlock-keychain -p 123456 build.keychain
         security import application_cert.p12 -k build.keychain -P $ITERATIVE_APPLICATION_CERT_PASS -T /usr/bin/codesign
-        security import installer_cert.p12 -k build.keychain -P $ITERATIVE_INSTALLER_CERT_PASS -T /usr/bin/productsign
         security set-key-partition-list -S 'apple-tool:,apple:,codesign:,productsign:' -s -k 123456 build.keychain
         security find-identity -v
-    - name: Check signing
-      run: |
-        which codesign
-        which productsign
-        codesign -f -s 62687162A75C39558A9EA17B57E8C65306BABE92 upload.py
+
     - name: Install requirements
       run: |
         pip install wheel
         pip install -r requirements.txt
-        brew install mitchellh/gon/gon
+
     - name: Download dvc pkg
       run: python download.py
+
     - name: Install dvc requirements
       run: |
         # available lxml (webdav dependency) wheels are built with an old
@@ -56,17 +51,144 @@ jobs:
         # instead.
         pip install ./dvc[all] --no-binary lxml
         pip install -r dvc/scripts/build-requirements.txt
+
+    - name: Build binary
+      run: |
+        echo 'PKG = "osxpkg"' > dvc/dvc/utils/build.py
+        python dvc/scripts/pyinstaller/build.py
+        cp -a dvc/scripts/pyinstaller/dist dist
+
+    - name: Sign binary
+      run: python sign_bin.py --application-id 62687162A75C39558A9EA17B57E8C65306BABE92 --keychain build.keychain
+
+    - name: Create tar with binary files
+      run: tar cvf dist.tar.gz dist
+
+    - name: Upload binary to artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: binary
+        path: dist.tar.gz
+        retention-days: 1
+
+  installer:
+    needs: binary
+    runs-on: macos-11
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - name: Install installer certificates
+      env:
+        ITERATIVE_INSTALLER_CERT: ${{ secrets.ITERATIVE_INSTALLER_CERT }}
+        ITERATIVE_INSTALLER_CERT_PASS: ${{ secrets.ITERATIVE_INSTALLER_CERT_PASS }}
+      run: |
+        echo $ITERATIVE_INSTALLER_CERT | base64 -d > installer_cert.p12
+        security create-keychain -p 123456 build.keychain
+        # NOTE: signing and steps before it might take longer than default 300 seconds, so we extend the
+        # timeout until the keychain automatically locks again.
+        security set-keychain-settings -lut 3600 build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p 123456 build.keychain
+        security import installer_cert.p12 -k build.keychain -P $ITERATIVE_INSTALLER_CERT_PASS -T /usr/bin/productsign
+        security set-key-partition-list -S 'apple-tool:,apple:,codesign:,productsign:' -s -k 123456 build.keychain
+
+    - name: Check certificates
+      run: security find-identity -v
+
+    - name: Install requirements
+      run: |
+        pip install wheel
+        pip install -r requirements.txt
         gem install --no-document fpm
-    - name: Build and sign
-      timeout-minutes: 120
+
+    - name: Download signed binary
+      uses: actions/download-artifact@v3
+      with:
+        name: binary
+
+    - name: Unpack tar with binary files
+      run: tar -xvf dist.tar.gz
+
+    - name: Build installer
+      run: python build_installer.py
+
+    - name: Sign installer
+      run: python sign_installer.py --installer-id 374191642324A98B1D9835CCD256EDEE2C710051 --keychain build.keychain
+
+    - name: Upload installer to artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: installer
+        path: dvc*.pkg
+        retention-days: 1
+
+  notarize:
+    needs: installer
+    runs-on: macos-11
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install requirements
+      run: |
+        brew install mitchellh/gon/gon
+
+    - name: Download signed installer
+      uses: actions/download-artifact@v3
+      with:
+        name: installer
+
+    - name: Notarize and staple installer
       env:
         APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-      run: |
-        sed -i "" "s/timeout=180/timeout=7200/g" dvc/scripts/pyinstaller/sign.py
-        python dvc/scripts/build.py osxpkg --sign-application --application-id 62687162A75C39558A9EA17B57E8C65306BABE92 --sign-installer --installer-id 374191642324A98B1D9835CCD256EDEE2C710051 --notarize --apple-id-username kupruser@gmail.com --apple-id-password $APPLE_ID_PASSWORD
+      run: python notarize_installer.py --apple-id-username kupruser@gmail.com --apple-id-password $APPLE_ID_PASSWORD
+
+    - name: Upload stapled installer to artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: stapled_installer
+        path: dvc*.pkg
+        retention-days: 1
+
+  upload:
+    needs: notarize
+    runs-on: ubuntu-latest
+    environment: aws
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install requirements
+      run: pip install awscli
+
+    - name: Download signed, notarized and stapled installer
+      uses: actions/download-artifact@v3
+      with:
+        name: stapled_installer
+
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::260760892802:role/dvc-public-osxpkg-deployer
-    - name: Upload
-      run: python upload.py dvc/scripts/fpm/dvc-*.pkg
+
+    - name: Upload to aws
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      run: python upload.py dvc-*.pkg

--- a/after-install.sh
+++ b/after-install.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+ln -sf /usr/local/lib/dvc/dvc /usr/local/bin/dvc

--- a/after-remove.sh
+++ b/after-remove.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+rm -rf /usr/local/bin/dvc

--- a/build_installer.py
+++ b/build_installer.py
@@ -1,0 +1,75 @@
+import os
+import pathlib
+import shutil
+from subprocess import STDOUT, check_call, check_output
+
+path = pathlib.Path(__file__).parent.absolute()
+build = path / "build"
+install = build / "usr"
+
+flags = [
+    "--description",
+    '"Data Version Control | Git for Data & Models"',
+    "-n",
+    "dvc",
+    "-s",
+    "dir",
+    "-f",
+    "--license",
+    '"Apache License 2.0"',
+]
+
+install /= "local"
+bash_dir = install / "etc" / "bash_completion.d"
+dirs = ["usr"]
+flags.extend(
+    [
+        "--osxpkg-identifier-prefix",
+        "com.iterative",
+        "--after-install",
+        path / "after-install.sh",
+        "--after-remove",
+        path / "after-remove.sh",
+    ]
+)
+
+try:
+    shutil.rmtree(build)
+except FileNotFoundError:
+    pass
+
+lib = install / "lib"
+lib.mkdir(parents=True)
+shutil.copytree(path / "dist" / "dvc", lib / "dvc")
+
+bash_dir.mkdir(parents=True)
+bash_completion = check_output(
+    [lib / "dvc" / "dvc", "completion", "-s", "bash"], text=True
+)
+(bash_dir / "dvc").write_text(bash_completion)
+
+zsh_dir = install / "share" / "zsh" / "site-functions"
+zsh_dir.mkdir(parents=True)
+zsh_completion = check_output(
+    [lib / "dvc" / "dvc", "completion", "-s", "zsh"], text=True
+)
+(zsh_dir / "_dvc").write_text(zsh_completion)
+
+version = check_output([lib / "dvc" / "dvc", "--version"], text=True).strip()
+
+check_call(
+    [
+        "fpm",
+        "--verbose",
+        "-t",
+        "osxpkg",
+        *flags,
+        "-v",
+        version,
+        "-C",
+        build,
+        *dirs,
+    ],
+    cwd=path,
+    stderr=STDOUT,
+)

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- These are required for binaries built by PyInstaller -->
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+</dict>
+</plist>

--- a/notarize_installer.py
+++ b/notarize_installer.py
@@ -1,0 +1,64 @@
+import argparse
+import json
+import os
+import pathlib
+import sys
+from subprocess import STDOUT, check_call
+
+if sys.platform != "darwin":
+    raise NotImplementedError
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "path",
+    nargs="?",
+    help="Path to the osxpkg to notarize. If not specified - try to find one.",
+)
+parser.add_argument("--apple-id-username", required=True, help="Apple ID username.")
+parser.add_argument(
+    "--apple-id-password",
+    required=True,
+    help=(
+        "Apple ID app-specific password. Note that this is not a regular "
+        "Apple ID password, so you need to generate one at "
+        "https://appleid.apple.com/account/manage"
+    ),
+)
+args = parser.parse_args()
+
+path = pathlib.Path(__file__).parent.absolute()
+
+if args.path:
+    pkg = pathlib.Path(args.path)
+else:
+    pkgs = list(path.glob("*.pkg"))
+    if not pkgs:
+        print("No pkgs found")
+        sys.exit(1)
+
+    if len(pkgs) > 1:
+        print("Too many packages")
+        sys.exit(1)
+
+    (pkg,) = pkgs
+
+
+config = {
+    "notarize": {
+        "path": os.fspath(pkg),
+        "bundle_id": "com.iterative.dvc",
+        "staple": True,
+    },
+    "apple_id": {
+        "username": args.apple_id_username,
+        "password": args.apple_id_password,
+    },
+}
+
+(path / "config.json").write_text(json.dumps(config))
+
+check_call(
+    ["gon", "config.json"],
+    cwd=path,
+    stderr=STDOUT,
+)

--- a/sign_bin.py
+++ b/sign_bin.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+import pathlib
+import sys
+from subprocess import STDOUT, check_call, CalledProcessError, TimeoutExpired
+
+if sys.platform != "darwin":
+    raise NotImplementedError
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--application-id",
+    required=True,
+    help="Certificate ID (should be added to the keychain).",
+)
+parser.add_argument(
+    "--keychain",
+    required=False,
+    help="Specify a specific keychain to search for the signing identity.",
+)
+args = parser.parse_args()
+
+path = pathlib.Path(__file__).parent.absolute()
+dvc = path / "dist" / "dvc"
+
+flags = []
+if args.keychain:
+    flags.extend(["--keychain", args.keychain])
+
+for root, _, fnames in os.walk(dvc):
+    for fname in fnames:
+        _, ext = os.path.splitext(fname)
+
+        fpath = os.path.join(root, fname)
+        print(f"signing {fpath}")
+
+        check_call(
+            [
+                "codesign",
+                "-s",
+                args.application_id,
+                *flags,
+                "-f",
+                "-v",
+                "--timestamp",
+                "-o",
+                "runtime",
+                "--entitlements",
+                "entitlements.plist",
+                fpath,
+            ],
+            timeout=10,
+            stderr=STDOUT,
+        )

--- a/sign_installer.py
+++ b/sign_installer.py
@@ -1,0 +1,66 @@
+import argparse
+import os
+import pathlib
+import sys
+from subprocess import STDOUT, check_call
+
+if sys.platform != "darwin":
+    raise NotImplementedError
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "path",
+    nargs="?",
+    help="Path to the osxpkg to sign. If not specified - try to find one.",
+)
+parser.add_argument(
+    "--installer-id",
+    required=True,
+    help="Certificate ID (should be added to the keychain).",
+)
+parser.add_argument(
+    "--keychain",
+    required=False,
+    help="Specify a specific keychain to search for the signing identity.",
+)
+args = parser.parse_args()
+
+path = pathlib.Path(__file__).parent.absolute()
+
+if args.path:
+    pkg = pathlib.Path(args.path)
+else:
+    pkgs = list(path.glob("*.pkg"))
+    if not pkgs:
+        print("No pkgs found")
+        sys.exit(1)
+
+    if len(pkgs) > 1:
+        print("Too many packages")
+        sys.exit(1)
+
+    (pkg,) = pkgs
+
+unsigned = pkg.with_suffix(".unsigned")
+os.rename(pkg, unsigned)
+
+flags = []
+if args.keychain:
+    flags.extend(["--keychain", args.keychain])
+
+check_call(
+    [
+        "productsign",
+        "--sign",
+        args.installer_id,
+        *flags,
+        os.fspath(unsigned),
+        os.fspath(pkg),
+    ],
+    stderr=STDOUT,
+)
+
+check_call(
+    ["pkgutil", "--check-signature", os.fspath(pkg)],
+    stderr=STDOUT,
+)


### PR DESCRIPTION
Turns out the keychain auto-locks in 300 seconds, and depending on how long
our previous stages take (e.g. pip install), it might be already locked when
we try to use it. The wild variations in `pip install` time are one of the reasons why
this was hard to reproduce and debug.

Revisited the structure of the process for easier maintainability and debugging
in the future. Will throw out migrated pieces from dvc main repo in the near future.

Fixes #106 