### PR TITLE
Use more or less recent macos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   binary:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Seem to be fixing the build issues. It installs Python 3.10.14 vs 3.10.13 on the main branch.